### PR TITLE
Fix TARGET_NAME typo in k_reorder and comment rmst_wl

### DIFF
--- a/dreamplace/BasicPlace.py
+++ b/dreamplace/BasicPlace.py
@@ -22,7 +22,7 @@ import dreamplace.ops.move_boundary.move_boundary as move_boundary
 import dreamplace.ops.hpwl.hpwl as hpwl
 import dreamplace.ops.density_overflow.density_overflow as density_overflow
 import dreamplace.ops.electric_potential.electric_overflow as electric_overflow
-import dreamplace.ops.rmst_wl.rmst_wl as rmst_wl
+#import dreamplace.ops.rmst_wl.rmst_wl as rmst_wl
 import dreamplace.ops.macro_legalize.macro_legalize as macro_legalize
 import dreamplace.ops.greedy_legalize.greedy_legalize as greedy_legalize
 import dreamplace.ops.abacus_legalize.abacus_legalize as abacus_legalize

--- a/dreamplace/ops/k_reorder/CMakeLists.txt
+++ b/dreamplace/ops/k_reorder/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(OP_NAME k_reorder)
 
+set(TARGET_NAME ${OP_NAME})
+
 set(INCLUDE_DIRS 
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${LIMBO_SOURCE_DIR}


### PR DESCRIPTION
- It seems that `rmst_wl` operator has been commented in the `dreamplace/ops/CMakeLists.txt` file. The `dreamplace/BasicPlace.py` file failed to import `rmst_wl`.
- `TARGET_NAME` is undefined in `dreamplace/ops/k_reorder/CMakeLists.txt`, so the libraries have incorrect names and cannot be found by Python scripts.