### PR TITLE
Support `torch=1.13`

### DIFF
--- a/dreamplace/ops/global_swap/src/global_swap_cuda.cpp
+++ b/dreamplace/ops/global_swap/src/global_swap_cuda.cpp
@@ -22,32 +22,6 @@ template <typename T>
 int globalSwapCUDALauncher(DetailedPlaceDB<T> db, int batch_size, int max_iters,
                            int num_threads);
 
-/// I remove the support to Char, since int8_t does not compile for CUDA
-/// char does not compile for ATen either
-#if TORCH_MAJOR_VERSION > 1 || (TORCH_MAJOR_VERSION == 1 && TORCH_MINOR_VERSION >= 8)
-#define DISPATCH_CUSTOM_TYPES(TYPE, NAME, ...)                              \
-  [&] {                                                                     \
-    switch (TYPE) {                                                         \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)       \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__)     \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int, __VA_ARGS__)           \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", at::toString(TYPE), "'"); \
-    }                                                                       \
-  }()
-#else
-#define DISPATCH_CUSTOM_TYPES(TYPE, NAME, ...)                              \
-  [&] {                                                                     \
-    switch (TYPE) {                                                         \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)       \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)     \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int, __VA_ARGS__)           \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", at::toString(TYPE), "'"); \
-    }                                                                       \
-  }()
-#endif
-
 at::Tensor global_swap_cuda_forward(
     at::Tensor init_pos, at::Tensor node_size_x, at::Tensor node_size_y,
     at::Tensor flat_region_boxes, at::Tensor flat_region_boxes_start,
@@ -66,7 +40,7 @@ at::Tensor global_swap_cuda_forward(
   auto pos = init_pos.clone();
 
   // Call the cuda kernel launcher
-  DISPATCH_CUSTOM_TYPES(pos.scalar_type(), "globalSwapCUDALauncher", [&] {
+  DREAMPLACE_DISPATCH_INT_FLOAT_TYPES(pos, "globalSwapCUDALauncher", [&] {
     auto db = make_placedb<scalar_t>(
         init_pos, pos, node_size_x, node_size_y, flat_region_boxes,
         flat_region_boxes_start, node2fence_region_map, flat_net2pin_map,

--- a/dreamplace/ops/utility/src/torch.h
+++ b/dreamplace/ops/utility/src/torch.h
@@ -7,6 +7,16 @@
 #ifndef _DREAMPLACE_UTILITY_TORCH_H
 #define _DREAMPLACE_UTILITY_TORCH_H
 
+#if TORCH_MAJOR_VERSION > 1 || (TORCH_MAJOR_VERSION == 1 && TORCH_MINOR_VERSION >= 13)
+
+#define AT_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
+  case enum_type: {                                      \
+    using scalar_t = type;                               \
+    return __VA_ARGS__();                                \
+  }
+
+#endif
+
 /// As torch may change the header inclusion conventions, it is better to manage
 /// it in a consistent way.
 #if TORCH_MAJOR_VERSION >= 1


### PR DESCRIPTION
[AT_PRIVATE_CASE_TYPE](https://github.com/pytorch/pytorch/commit/2c43876f64603d6ccaedcf6a95f3a10319c754e6#diff-adf02633c28e4ed718bc830d445ced3c4acdf464b4962b86b3a82424ded6a181L76) was recently removed from the public dispatch API (look in the `Dispatch.h` diff). Put it back in `torch.h` so that we can use `torch=1.13` and higher CUDA gencodes.

With these changes I am able to build in this env:

```
(dreamplaceasic) mlevental@mlevental-CORSAIR-ONE-PRO-a200:~/dev_projects/DREAMPlace$ pip freeze
torch==1.13.0.dev20220812
torchaudio==0.13.0.dev20220812
torchtext==0.14.0.dev20220812
torchvision==0.14.0.dev20220812

(dreamplaceasic) mlevental@mlevental-CORSAIR-ONE-PRO-a200:~/dev_projects/DREAMPlace$ nvidia-smi
Fri Aug 12 17:06:44 2022       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 515.65.01    Driver Version: 515.65.01    CUDA Version: 11.7     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  Off  | 00000000:06:00.0  On |                  N/A |
|  0%   30C    P8    35W / 320W |    961MiB / 10240MiB |      1%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A      1463      G   /usr/lib/xorg/Xorg                525MiB |
|    0   N/A  N/A      1940      G   ...ome-remote-desktop-daemon        3MiB |
|    0   N/A  N/A      4683      G   gnome-control-center               67MiB |
|    0   N/A  N/A    166784      G   /usr/bin/gnome-shell              142MiB |
|    0   N/A  N/A    171137      G   ...528177628034215241,131072      219MiB |
+-----------------------------------------------------------------------------+
```

and pass tests

```
(dreamplaceasic) mlevental@mlevental-CORSAIR-ONE-PRO-a200:~/dev_projects/DREAMPlace$ PYTHONPATH=install python unittest/ops/hpwl_unittest.py 
/home/mlevental/dev_projects/DREAMPlace/unittest/ops/hpwl_unittest.py:41: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  net2pin_map = np.array([np.array([0, 4]), np.array([1, 2, 3])])
net_weights =  [1. 2.]
flat_net2pin_map =  [0 4 1 2 3]
flat_net2pin_start_map =  [0 2 5]
pin2net_map =  [0 1 1 1 0]
net_mask =  [1 1]
golden_value =  9.499999761581421
[[0.  1.  1.5 0.5 0.6]
 [0.  2.  0.2 3.1 1.1]]
tensor([[0.0000, 0.0000],
        [1.0000, 2.0000],
        [1.5000, 0.2000],
        [0.5000, 3.1000],
        [0.6000, 1.1000]])
hpwl_value =  9.5
hpwl_value cuda =  9.5
hpwl_value atomic =  9.5
hpwl_value cuda atomic =  9.5
.
----------------------------------------------------------------------
Ran 1 test in 0.624s

OK
```

Let me know if there's something else you'd like me to do/change here in order to land.

