### PR TITLE
Rotates the NVIDIA keys that cause failure when running apt-get update.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,33 @@
 FROM pytorch/pytorch:1.7.1-cuda11.0-cudnn8-devel
 LABEL maintainer="Yibo Lin <yibolin@pku.edu.cn>"
 
-# install system dependency 
+# Rotates to the keys used by NVIDIA as of 27-APR-2022.
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+
+# Installs system dependencies .
 RUN apt-get update \
         && apt-get install -y \
-            wget \
             flex \
             libcairo2-dev \
             libboost-all-dev 
 
-# install system dependency from conda
+
+# Installs system dependencies from conda.
 RUN conda install -y -c conda-forge bison
 
-# install cmake
+# Install cmake
 ADD https://cmake.org/files/v3.21/cmake-3.21.0-linux-x86_64.sh /cmake-3.21.0-linux-x86_64.sh
 RUN mkdir /opt/cmake \
         && sh /cmake-3.21.0-linux-x86_64.sh --prefix=/opt/cmake --skip-license \
         && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
         && cmake --version
 
-# install python dependency 
+# installs python dependencies. 
 RUN pip install \
         pyunpack>=0.1.2 \
         patool>=1.12 \
@@ -30,4 +38,3 @@ RUN pip install \
         scipy>=1.1.0 \
         numpy>=1.15.4 \
         shapely>=1.7.0
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 
 
-# Installs system dependencies .
+# Installs system dependencies.
 RUN apt-get update \
         && apt-get install -y \
             flex \
@@ -20,14 +20,14 @@ RUN apt-get update \
 # Installs system dependencies from conda.
 RUN conda install -y -c conda-forge bison
 
-# Install cmake
+# Installs cmake.
 ADD https://cmake.org/files/v3.21/cmake-3.21.0-linux-x86_64.sh /cmake-3.21.0-linux-x86_64.sh
 RUN mkdir /opt/cmake \
         && sh /cmake-3.21.0-linux-x86_64.sh --prefix=/opt/cmake --skip-license \
         && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
         && cmake --version
 
-# installs python dependencies. 
+# Installs python dependencies. 
 RUN pip install \
         pyunpack>=0.1.2 \
         patool>=1.12 \


### PR DESCRIPTION
NVIDIA rotates their keys every so often. It looks like they rotated them in April-2022 which was after the PyTorch 1.7.x Docker image was created. Using a PyTorch docker image from March or later in 2022 would likely also fix this. But I thought it was best to start with fixing the "as-is" docker; rather than seeing how fresh of a PyTorch version will work.  

Here is the info from [NVIDIA](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772)

Thank you for a great piece of software. :-)