### PR TITLE
Use set_to_none=False to be compatible with pytorch2.0

### DIFF
--- a/dreamplace/NonLinearPlace.py
+++ b/dreamplace/NonLinearPlace.py
@@ -274,7 +274,7 @@ class NonLinearPlace(BasicPlace.BasicPlace):
                                 % ", ".join(["%.3E" % i for i in model.density_weight.cpu().numpy().tolist()])
                             )
 
-                    optimizer.zero_grad()
+                    optimizer.zero_grad(set_to_none=False)
 
                     # t1 = time.time()
                     cur_metric.evaluate(placedb, eval_ops, pos, model.data_collections)


### PR DESCRIPTION
Pytorch2.0 will by default set it to True. We have to explicitly set this option to False because there are logic in https://github.com/limbo018/DREAMPlace/blob/b31e8afa60775bfefdcbb52c0926c6167ec394f6/dreamplace/NesterovAcceleratedGradientOptimizer.py#L71-L72 that does things differently if grad is none.

Note that this option is available only since torch1.7.  I'm not sure if the PR needs to support torch<1.7 as well.