### PR TITLE
fix bug

### DIFF
--- a/dreamplace/ops/place_io/src/Enums.cpp
+++ b/dreamplace/ops/place_io/src/Enums.cpp
@@ -6,6 +6,7 @@
  ************************************************************************/
 
 #include "Enums.h"
+#include <typeinfo>
 
 DREAMPLACE_BEGIN_NAMESPACE
 


### PR DESCRIPTION
Add ‘#include <typeinfo>’ in Enums.cpp to avoid unexpected error during cmake.