### PR TITLE
Fixing the issue that results in returning 'INF' when calculating HPWL.

### DIFF
--- a/dreamplace/ops/hpwl/src/hpwl.cpp
+++ b/dreamplace/ops/hpwl/src/hpwl.cpp
@@ -74,7 +74,16 @@ int computeHPWLLauncher(const T* x, const T* y, const int* flat_netpin,
         min_y = std::min(min_y, y[flat_netpin[j]]);
         max_y = std::max(max_y, y[flat_netpin[j]]);
       }
-      hpwl[i] = max_x - min_x + max_y - min_y;
+
+      // Return 0 if the net has no pins.
+      if (max_x == -std::numeric_limits<T>::max() ||
+          min_x == std::numeric_limits<T>::max() ||
+          max_y == -std::numeric_limits<T>::max() ||
+          min_y == std::numeric_limits<T>::max()) {
+        hpwl[i] = 0;
+      } else {
+        hpwl[i] = max_x - min_x + max_y - min_y;
+      }
     }
   }
 

--- a/dreamplace/ops/hpwl/src/hpwl_atomic.cpp
+++ b/dreamplace/ops/hpwl/src/hpwl_atomic.cpp
@@ -60,6 +60,19 @@ at::Tensor hpwl_atomic_forward(at::Tensor pos, at::Tensor pin2net_map,
   // std::cout << "partial_hpwl = \n" <<
   // (partial_hpwl_max-partial_hpwl_min).to(torch::kDouble).mul(1.0/1000) << "\n";
 
+DREAMPLACE_DISPATCH_FLOATING_TYPES(
+    pos, "get_scalar_t_type", [&] {
+      // define min, max and zero value for scalar_t type
+      auto min_value = std::numeric_limits<scalar_t>::min();
+      auto max_value = std::numeric_limits<scalar_t>::max();
+      auto zero_value = static_cast<scalar_t>(0);
+      // replace min or max value with zero
+      partial_hpwl_max.masked_fill_(partial_hpwl_max == min_value, zero_value);
+      partial_hpwl_max.masked_fill_(partial_hpwl_max == min_value, zero_value);
+      partial_hpwl_min.masked_fill_(partial_hpwl_min == max_value, zero_value);
+      partial_hpwl_min.masked_fill_(partial_hpwl_min == max_value, zero_value);
+    });
+
   auto hpwl = (partial_hpwl_max - partial_hpwl_min);
   if (net_weights.numel()) {
     hpwl.mul_(net_weights.view({1, num_nets}));

--- a/dreamplace/ops/hpwl/src/hpwl_cuda_atomic.cpp
+++ b/dreamplace/ops/hpwl/src/hpwl_cuda_atomic.cpp
@@ -60,6 +60,14 @@ at::Tensor hpwl_atomic_forward(at::Tensor pos, at::Tensor pin2net_map,
   // std::cout << "partial_hpwl = \n" <<
   // (partial_hpwl_max-partial_hpwl_min).to(torch::kDouble).mul(1.0/1000) << "\n";
 
+  auto min_value = std::numeric_limits<T>::min();
+  auto max_value = std::numeric_limits<T>::max();
+  auto zero_value = static_cast<T>(0);
+  // replace min or max value with zero
+  partial_hpwl_max.masked_fill_(partial_hpwl_max == min_value, zero_value);
+  partial_hpwl_max.masked_fill_(partial_hpwl_max == max_value, zero_value);
+  partial_hpwl_min.masked_fill_(partial_hpwl_min == min_value, zero_value);
+  partial_hpwl_min.masked_fill_(partial_hpwl_min == max_value, zero_value);
   auto delta = partial_hpwl_max - partial_hpwl_min;
 
   at::Tensor hpwl;

--- a/dreamplace/ops/hpwl/src/hpwl_cuda_kernel.cu
+++ b/dreamplace/ops/hpwl/src/hpwl_cuda_kernel.cu
@@ -29,11 +29,11 @@ __global__ void computeHPWL(
                 min_x = min(min_x, x[flat_netpin[j]]);
                 max_x = max(max_x, x[flat_netpin[j]]);
             }
-            partial_hpwl[i] = max_x-min_x;
         }
-        else
-        {
+        if (max_x == -FLT_MAX || min_x == FLT_MAX) {
             partial_hpwl[i] = 0;
+        } else {
+            partial_hpwl[i] = max_x-min_x;
         }
     }
 }


### PR DESCRIPTION
Fixing the issue in the ops/hpwl where it returns INF/-INF when the net has no pins.