### PR TITLE
Fix deprecated alias 'np.str' in PlaceDB.py

### DIFF
--- a/dreamplace/PlaceDB.py
+++ b/dreamplace/PlaceDB.py
@@ -1042,8 +1042,8 @@ row height = %g, site width = %g
         tt = time.time()
         logging.info("writing to %s" % (pl_file))
         content = "UCLA pl 1.0\n"
-        str_node_names = np.array(self.node_names).astype(np.str)
-        str_node_orient = np.array(self.node_orient).astype(np.str)
+        str_node_names = np.array(self.node_names).astype(np.str_)
+        str_node_orient = np.array(self.node_orient).astype(np.str_)
         for i in range(self.num_movable_nodes):
             content += "\n%s %g %g : %s" % (
                     str_node_names[i],


### PR DESCRIPTION
When I use numpy version 1.20+ and only do global placement without legalize and detailed placement operations, it throws an exception:
``` bash
Traceback (most recent call last):
  File "/home/ubuntu/dp_4/dreamplace/Placer.py", line 192, in <module>
    place(params)
  File "/home/ubuntu/dp_4/dreamplace/Placer.py", line 76, in place
    placedb.write(params, gp_out_file)
  File "/home/ubuntu/dp_4/dreamplace/PlaceDB.py", line 1007, in write
    self.write_pl(params, filename, node_x, node_y)
  File "/home/ubuntu/dp_4/dreamplace/PlaceDB.py", line 1045, in write_pl
    str_node_names = np.array(self.node_names).astype(np.str)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'str'.
`np.str` was a deprecated alias for the builtin `str`. To avoid this error in existing code, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'std'?
```
Checking the related information, I found that the np.str method was deprecated in numpy after version 1.20. So replace np.str with np.str_ and the problem is fixed.