### PR TITLE
Build timing_op only if params.timing_opt_flag is enabled

### DIFF
--- a/dreamplace/BasicPlace.py
+++ b/dreamplace/BasicPlace.py
@@ -402,7 +402,8 @@ class BasicPlace(nn.Module):
         # rectilinear minimum steiner tree wirelength from flute
         # can only be called once
         #self.op_collections.rmst_wl_op = self.build_rmst_wl(params, placedb, self.op_collections.pin_pos_op, torch.device("cpu"))
-        self.op_collections.timing_op = self.build_timing_op(params, placedb, timer)
+        if params.timing_opt_flag:
+            self.op_collections.timing_op = self.build_timing_op(params, placedb, timer)
         # legality check
         self.op_collections.legality_check_op = self.build_legality_check(
             params, placedb, self.data_collections, self.device)

--- a/dreamplace/NonLinearPlace.py
+++ b/dreamplace/NonLinearPlace.py
@@ -52,8 +52,8 @@ class NonLinearPlace(BasicPlace.BasicPlace):
         """
         iteration = 0
         all_metrics = []
-        timing_op = self.op_collections.timing_op
         if params.timing_opt_flag:
+            timing_op = self.op_collections.timing_op
             time_unit = timing_op.timer.time_unit()
 
         # global placement


### PR DESCRIPTION
``timing_op`` should be built only if ``params.timing_opt_flag`` is enabled. If ``params.timing_opt_flag`` is disabled, then ``timing_op`` is not needed.