### PR TITLE
Fix: Skip comment lines in .pl file parsing

### DIFF
--- a/dreamplace/PlaceDB.py
+++ b/dreamplace/PlaceDB.py
@@ -1022,7 +1022,7 @@ row height = %g, site width = %g
         with open(pl_file, "r") as f:
             for line in f:
                 line = line.strip()
-                if line.startswith("UCLA"):
+                if line.startswith("UCLA") or line.startswith("#"):
                     continue
                 # node positions
                 pos = re.search(r"(\w+)\s+([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)\s+([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)\s*:\s*(\w+)", line)


### PR DESCRIPTION
## Issue
The regex pattern was incorrectly matching comment lines (starting with "#") as node position data, causing KeyError when accessing `node_name2id_map`.

## Fix
Added `line.startswith("#")` condition to skip comment lines before regex matching.

## Changes
- Added comment line filtering in PlaceDB.py
- Prevents parsing of comment content as node names
- Maintains existing functionality for valid node position lines