### PR TITLE
Fix CUB compilation errors with CUDA 12.x by removing namespace wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,14 +78,18 @@ message(STATUS "FLUTE_INCLUDE_DIRS ${FLUTE_INCLUDE_DIRS}")
 message(STATUS "FLUTE_LINK_DIRS ${FLUTE_LINK_DIRS}")
 include_directories(${FLUTE_INCLUDE_DIRS})
 
-# Limbo for parsers 
+# Limbo for parsers
 set(LIMBO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/Limbo)
 message(STATUS "LIMBO_SOURCE_DIR ${LIMBO_SOURCE_DIR}")
 set(LIMBO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty/Limbo)
 message(STATUS "LIMBO_BINARY_DIR ${LIMBO_BINARY_DIR}")
 if(CUDA_FOUND)
+  # Always use system CUB for CUDA 11+ to avoid version conflicts
+  # CUDA 11+ includes a newer CUB version that supports cuda::std namespace
   if (${CUDA_VERSION_MAJOR} VERSION_GREATER_EQUAL "11")
     set(CUB_DIR ${CUDA_INCLUDE_DIRS})
+    # Explicitly exclude old CUB from include paths
+    list(REMOVE_ITEM CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cub)
   else()
     set(CUB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cub)
   endif()

--- a/dreamplace/ops/utility/src/utils_cub.cuh
+++ b/dreamplace/ops/utility/src/utils_cub.cuh
@@ -12,12 +12,24 @@
 #include "utility/src/namespace.h"
 
 // include cub in a safe manner
-#define CUB_NS_PREFIX namespace DREAMPLACE_NAMESPACE {
-#define CUB_NS_POSTFIX }
-#define CUB_NS_QUALIFIER DREAMPLACE_NAMESPACE::cub
-#include "cub/cub.cuh"
-#undef CUB_NS_QUALIFIER
-#undef CUB_NS_POSTFIX
-#undef CUB_NS_PREFIX
+// For CUDA 11+, we cannot use CUB_NS_PREFIX/CUB_NS_POSTFIX because
+// the newer CUB uses cuda::std namespace which cannot be wrapped
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ >= 11)
+  // CUDA 11+: Use system CUB without namespace wrapping
+  #include <cub/cub.cuh>
+  // Create an alias in DreamPlace namespace for compatibility
+  namespace DREAMPLACE_NAMESPACE {
+    namespace cub = ::cub;
+  }
+#else
+  // CUDA 10 and below: Use bundled CUB with namespace wrapping
+  #define CUB_NS_PREFIX namespace DREAMPLACE_NAMESPACE {
+  #define CUB_NS_POSTFIX }
+  #define CUB_NS_QUALIFIER DREAMPLACE_NAMESPACE::cub
+  #include "cub/cub.cuh"
+  #undef CUB_NS_QUALIFIER
+  #undef CUB_NS_POSTFIX
+  #undef CUB_NS_PREFIX
+#endif
 
 #endif


### PR DESCRIPTION
### Problem

When compiling DREAMPlace with CUDA 12.x, the build fails with numerous errors from CUB headers such as `agent_three_way_partition.cuh` and `tuning_three_way_partition.cuh`. Example errors include:

```
error: name followed by "::" must be a class or namespace name
  struct accumulator_pack_base_t<OffsetT, typename cuda::std::enable_if<sizeof(OffsetT) == 4>::type>
                                                         ^
```

### Root Cause

The issue stems from two sources:

1. **Namespace wrapping incompatibility**: The project's `utils_cub.cuh` header wraps CUB includes with `CUB_NS_PREFIX`/`CUB_NS_POSTFIX` macros to place CUB inside the `DreamPlace` namespace. This technique was compatible with older CUB versions but breaks with CUDA 11+ where CUB uses the `cuda::std` namespace internally, which cannot be wrapped.

2. **Potential version conflict**: For CUDA 11+, the system CUB should be used exclusively, but the build configuration did not properly exclude the bundled old CUB (v1.8.0 from 2018) from include paths.

### Solution

1. **Modified `dreamplace/ops/utility/src/utils_cub.cuh`**: Added conditional compilation to skip namespace wrapping for CUDA 11+. For CUDA 11+, we include the system CUB directly and create a namespace alias for compatibility. For CUDA 10 and below, we continue using the bundled CUB with namespace wrapping.

2. **Modified `CMakeLists.txt`**: Enhanced the CUB configuration to explicitly exclude the bundled CUB from `CMAKE_PREFIX_PATH` when using CUDA 11+, preventing accidental inclusion of the old CUB headers.
